### PR TITLE
Bugfix: security-credentials profile not instance profile

### DIFF
--- a/aws/aws-credentials.sh
+++ b/aws/aws-credentials.sh
@@ -65,7 +65,16 @@ function aws_instance_profile_name() {
 #           "Expiration": "2020-04-02T00:49:51Z"
 #   }
 function aws_credentials() {
-  curl -s "${METADATA}/iam/security-credentials/$(aws_instance_profile_name)"
+  local credentials profile
+
+  credentials=$(curl -s "${METADATA}/iam/security-credentials/$(aws_instance_profile_name)")
+
+  if [[ -n "${credentials}" ]]; then
+    profile=$(curl -s "${METADATA}/iam/security-credentials/")
+    credentials=$(curl -s "${METADATA}/iam/security-credentials/${profile}")
+  fi
+
+  echo "${credentials}"
 }
 
 # @description


### PR DESCRIPTION
# Pull Request

## Description
<!-- Describe your changes in detail -->
<!-- Cite ALL GitHub issues -->
- In some situations, the profile available at `iam/security-credentials/` is not the same as the instance profile arn
- Add some checking at `aws_credentials()` to handle profile dfferences

Signed-off-by: Brian Menges <@mengesb>

## Types of changes
<!--- Put an `x` in **ONE** the boxes. -->
<!--- To fill in a selection, place an `x` in the box like so: [x] -->
<!--- Questions? Don't hesitate to ask. We're here to help! -->
- [x] PATCH change (a.b.PATCH) - adding configuration or non-breaking fix
- [ ] FEATURE change (a.FEATURE.0) - non-breaking change which adds
  functionality
- [ ] MAJOR change (MAJOR.0.0) - fix or feature that would cause existing
  functionality to not work as expected

## Checklist
<!--- Put an `x` in all the boxes that apply. -->
<!--- Questions? Don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (linting).
- [x] Tests added/amended and passing
