### PR TITLE
Update GitHub Actions to current versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/bats-unit.yml
+++ b/.github/workflows/bats-unit.yml
@@ -14,16 +14,17 @@ jobs:
   unit:
     runs-on: ubuntu-24.04
     steps:
-    - name: Setup BATS
-      uses: mig4/setup-bats@v1
-      with:
-        bats-version: 1.11.1
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         submodules: true
+
+    - name: Setup BATS
+      shell: bash
+      run: |
+        git clone --depth 1 --branch v1.11.1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+        sudo /tmp/bats-core/install.sh /usr/local
 
     - name: Checkout shdoc
       uses: actions/checkout@v4
@@ -49,9 +50,11 @@ jobs:
         echo "Test: test/requirements.bats"
         bats test/requirements.bats
         for f in $(ls test/*.bats | grep -v requirements); do
+          pkill -f ec2-metadata-mock || true
+          sleep 1
           echo "TEST: $f" && bats $f
           RET=$?
-          [[ "${RET}" -eq 0 ]] && sleep 1 && echo ""
           [[ "${RET}" -ne 0 ]] && exit 1
         done
+        pkill -f ec2-metadata-mock || true
         exit "${RET}"

--- a/.github/workflows/bats-unit.yml
+++ b/.github/workflows/bats-unit.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup BATS
       shell: bash
       run: |
-        git clone --depth 1 --branch v1.11.1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+        git clone --depth 1 --branch v1.2.1 https://github.com/bats-core/bats-core.git /tmp/bats-core
         sudo /tmp/bats-core/install.sh /usr/local
 
     - name: Checkout shdoc
@@ -50,11 +50,9 @@ jobs:
         echo "Test: test/requirements.bats"
         bats test/requirements.bats
         for f in $(ls test/*.bats | grep -v requirements); do
-          pkill -f ec2-metadata-mock || true
-          sleep 1
           echo "TEST: $f" && bats $f
           RET=$?
+          [[ "${RET}" -eq 0 ]] && sleep 1 && echo ""
           [[ "${RET}" -ne 0 ]] && exit 1
         done
-        pkill -f ec2-metadata-mock || true
         exit "${RET}"

--- a/.github/workflows/bats-unit.yml
+++ b/.github/workflows/bats-unit.yml
@@ -12,21 +12,21 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Setup BATS
       uses: mig4/setup-bats@v1
       with:
-        bats-version: 1.2.1
+        bats-version: 1.11.1
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         submodules: true
 
     - name: Checkout shdoc
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: shdoc
         repository: reconquest/shdoc
@@ -35,7 +35,7 @@ jobs:
     - name: Setup requirements
       shell: bash
       run: |
-        sudo curl -Lo /usr/local/bin/ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v1.8.1/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
+        sudo curl -Lo /usr/local/bin/ec2-metadata-mock https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v1.13.0/ec2-metadata-mock-`uname | tr '[:upper:]' '[:lower:]'`-amd64
         sudo chmod a+x /usr/local/bin/ec2-metadata-mock
         cd shdoc
         sudo make install

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,11 +11,18 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/shell-docs.yml
+++ b/.github/workflows/shell-docs.yml
@@ -3,17 +3,20 @@ name: Generate shell script docs
 on:
   - pull_request
 
+permissions:
+  contents: write
+
 jobs:
   shdoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Checkout shdoc
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: shdoc
         repository: reconquest/shdoc
@@ -52,4 +55,3 @@ jobs:
           git commit -am "shdoc: Automated shell script document updates" > /dev/null || echo "Nothing to commit"
           git push --quiet
         fi
-        

--- a/.github/workflows/shellcheck-lint.yml
+++ b/.github/workflows/shellcheck-lint.yml
@@ -6,18 +6,13 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           submodules: true
-
-      - name: Setup shellcheck
-        shell: bash
-        run: |
-          sudo apt-get -y install shellcheck
 
       - name: shellcheck
         shell: bash

--- a/docs/aws/aws-credentials.md
+++ b/docs/aws/aws-credentials.md
@@ -13,15 +13,15 @@ This code handles environments where `jq` may not be available.
 
 ## Index
 
-* [aws_instance_profile_arn()](#aws_instance_profile_arn)
-* [aws_instance_profile_name()](#aws_instance_profile_name)
-* [aws_credentials()](#aws_credentials)
-* [aws_access_key_id()](#aws_access_key_id)
-* [aws_secret_access_key()](#aws_secret_access_key)
-* [aws_session_token()](#aws_session_token)
-* [aws_environment()](#aws_environment)
+* [aws_instance_profile_arn](#aws_instance_profile_arn)
+* [aws_instance_profile_name](#aws_instance_profile_name)
+* [aws_credentials](#aws_credentials)
+* [aws_access_key_id](#aws_access_key_id)
+* [aws_secret_access_key](#aws_secret_access_key)
+* [aws_session_token](#aws_session_token)
+* [aws_environment](#aws_environment)
 
-### aws_instance_profile_arn()
+### aws_instance_profile_arn
 
 Acquires your instance profile ARN from the metadata API
 
@@ -33,7 +33,7 @@ $ aws_instance_profile_arn
 arn:aws:iam::896453262835:instance-profile/baskinc-role
 ```
 
-### aws_instance_profile_name()
+### aws_instance_profile_name
 
 Acquires your profile name from aws_instance_profile_arn() function
 
@@ -45,7 +45,7 @@ $ aws_instance_profile_name
 baskinc-role
 ```
 
-### aws_credentials()
+### aws_credentials
 
 Acquires your security credentials for your AWS instance profile
 
@@ -65,7 +65,7 @@ $ aws_credentials
 }
 ```
 
-### aws_access_key_id()
+### aws_access_key_id
 
 Acquires your AWS Access Key ID from aws_credentials() function
 
@@ -77,7 +77,7 @@ $ aws_access_key_id
 12345678901
 ```
 
-### aws_secret_access_key()
+### aws_secret_access_key
 
 Acquires your AWS Secret Access Key from aws_credentials() function
 
@@ -89,7 +89,7 @@ $ aws_secret_access_key
 v/12345678901
 ```
 
-### aws_session_token()
+### aws_session_token
 
 Acquires your AWS Session Token from aws_credentials() function
 
@@ -101,7 +101,7 @@ $ aws_session_token
 TEST92test48TEST+y6RpoTEST92test48TEST/8oWVAiBqTEsT5Ky7ty2tEStxC1T==
 ```
 
-### aws_environment()
+### aws_environment
 
 Outputs environment variable exports for your AWS credentials
 

--- a/docs/aws/aws4-sign.md
+++ b/docs/aws/aws4-sign.md
@@ -9,12 +9,12 @@ This library builds an AWS signature version 4 compatible request
 
 ## Index
 
-* [AWS4_HMAC_SHA256()](#aws4_hmac_sha256)
-* [AWS4_SHA256()](#aws4_sha256)
-* [AWS4_BASE64()](#aws4_base64)
-* [AWS4_SIGN()](#aws4_sign)
+* [AWS4_HMAC_SHA256](#aws4_hmac_sha256)
+* [AWS4_SHA256](#aws4_sha256)
+* [AWS4_BASE64](#aws4_base64)
+* [AWS4_SIGN](#aws4_sign)
 
-### AWS4_HMAC_SHA256()
+### AWS4_HMAC_SHA256
 
 Generates a HMAC SHA256 digest with date and AWS_SECRET_ACCESS_KEY
 
@@ -26,7 +26,7 @@ $ printf '%s' $(TZ=Z date +%Y%m%dT%H%M%SZ) | AWS4_HMAC_SHA256 "key:AWS4v/1234567
 79ee5040070df9e44dcf8311c8c39f1e80ad2129427203922bd843d0e5a4a246
 ```
 
-### AWS4_SHA256()
+### AWS4_SHA256
 
 Generates a SHA256 digest of the iam_request_body
 
@@ -38,7 +38,7 @@ $ printf '%s' "Action=GetCallerIdentity&Version=2011-06-15" | AWS4_SHA256
 ab821ae955788b0e33ebd34c208442ccfc2d406e2edc5e7a39bd6458fbb4f843
 ```
 
-### AWS4_BASE64()
+### AWS4_BASE64
 
 Encodes a string to base64
 
@@ -50,7 +50,7 @@ $ printf '%s' "https://sts.amazon.com/" | AWS4_BASE64
 aHR0cHM6Ly9zdHMuYW1hem9uLmNvbS8=
 ```
 
-### AWS4_SIGN()
+### AWS4_SIGN
 
 Generate a full AWS Signature v4 string
 

--- a/docs/aws/vault-iam-auth.md
+++ b/docs/aws/vault-iam-auth.md
@@ -58,5 +58,26 @@ $ aws/vault-iam-auth.sh -s https://my-internal-vault.domain.tld
 }
 ```
 
+## Index
 
+* [vault_iam_auth](#vault_iam_auth)
+
+### vault_iam_auth
+
+Generates JSON material for login
+
+#### Example
+
+```bash
+$ aws/vault-iam-auth.sh -r my-vault-role
+{
+  "role": "my-vault-role",
+  "iam_http_request_method": "POST",
+  "iam_request_url": "[[base64 encoded material]]",
+  "iam_request_body": "[[base64 encoded material]]",
+  "iam_request_headers": "[[base64 encoded material]]"
+}
+```
+
+_Function has no arguments._
 

--- a/docs/functions/jwt-decode.md
+++ b/docs/functions/jwt-decode.md
@@ -9,16 +9,16 @@ This library decodes JWT material
 
 ## Index
 
-* [b64_padding()](#b64_padding)
-* [b64_tr()](#b64_tr)
-* [json_kv()](#json_kv)
-* [google_pubkey()](#google_pubkey)
-* [google_verify()](#google_verify)
-* [jwt_header_json()](#jwt_header_json)
-* [jwt_payload_json()](#jwt_payload_json)
-* [jwt_display()](#jwt_display)
+* [b64_padding](#b64_padding)
+* [b64_tr](#b64_tr)
+* [json_kv](#json_kv)
+* [google_pubkey](#google_pubkey)
+* [google_verify](#google_verify)
+* [jwt_header_json](#jwt_header_json)
+* [jwt_payload_json](#jwt_payload_json)
+* [jwt_display](#jwt_display)
 
-### b64_padding()
+### b64_padding
 
 Parses a base64 padded JWT string
 
@@ -38,7 +38,7 @@ eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTBhYmNkZWYwMTIzNDU2Nzg5MGFiY2RlZjEyMzQ1
 
 * base64 encoded string with propper padding/terminators
 
-### b64_tr()
+### b64_tr
 
 Base64 translate of a JWT encoded string
 
@@ -58,7 +58,7 @@ eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTBhYmNkZWYwMTIzNDU2Nzg5MGFiY2RlZjEyMzQ1
 
 * base64 encoded string replacing '-_' with '+/'
 
-### json_kv()
+### json_kv
 
 Parses JSON string and returns value of key requested
 
@@ -79,7 +79,7 @@ RS256
 
 * value of key searched for, or 'null' if not found
 
-### google_pubkey()
+### google_pubkey
 
 Google OAuth2 public key signature fetch
 
@@ -99,7 +99,7 @@ $ google_pubkey '13e8d45a43cb2242154c7f4dafac2933fea20374'
 
 * File containing public key material
 
-### google_verify()
+### google_verify
 
 Google OAuth2 veriification of JWT header + payload (i.e. body) with
 signature
@@ -120,7 +120,7 @@ Verified OK
 
 * Message indicating success or failure of JWT verification
 
-### jwt_header_json()
+### jwt_header_json
 
 Parses JWT material and returns decoded JWT header
 
@@ -140,7 +140,7 @@ $ jwt_header_json 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTBhYmNkZWYwMTIzNDU2N
 
 * base64 decoded JWT header
 
-### jwt_payload_json()
+### jwt_payload_json
 
 Parses JWT material and returns decoded JWT payload
 
@@ -160,7 +160,7 @@ $ jwt_payload_json 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTBhYmNkZWYwMTIzNDU2
 
 * base64 decoded JWT payload
 
-### jwt_display()
+### jwt_display
 
 Parses JWT material and returns environment variables
 

--- a/docs/functions/parse-url.md
+++ b/docs/functions/parse-url.md
@@ -17,9 +17,9 @@ Will take an URL as an input, and break it into the following components:
 
 ## Index
 
-* [parse_url()](#parse_url)
+* [parse_url](#parse_url)
 
-### parse_url()
+### parse_url
 
 Parse URL string
 

--- a/docs/gcp/gcp-credentials.md
+++ b/docs/gcp/gcp-credentials.md
@@ -13,12 +13,12 @@ This code handles environments where `jq` may not be available.
 
 ## Index
 
-* [headers()](#headers)
-* [url_encode()](#url_encode)
-* [gcp_identity()](#gcp_identity)
-* [gcp_service_accounts()](#gcp_service_accounts)
+* [headers](#headers)
+* [url_encode](#url_encode)
+* [gcp_identity](#gcp_identity)
+* [gcp_service_accounts](#gcp_service_accounts)
 
-### headers()
+### headers
 
 Builds headers for curl requests from HEADERS environment variable
 
@@ -30,7 +30,7 @@ $ headers
 -H 'Metadata-Flavor: Google'
 ```
 
-### url_encode()
+### url_encode
 
 Builds url encoding commands for curl requests
 
@@ -48,7 +48,7 @@ $ url_encode "audience=https://vault"
 
 * **$1** (string): Data to encode in URL safe format
 
-### gcp_identity()
+### gcp_identity
 
 Returns a GCE instance identity (JWT token) for the audience requested
 
@@ -64,7 +64,7 @@ eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTBhYmNkZWYxMjM0NTY3ODkwYWJjZGVmMTIzNDU2
 
 * **$1** (string): Audience to request JWT token for
 
-### gcp_service_accounts()
+### gcp_service_accounts
 
 Returns information about a service accunt, or the default if none passed
 

--- a/docs/gcp/vault-gce-auth.md
+++ b/docs/gcp/vault-gce-auth.md
@@ -100,5 +100,24 @@ $ gcp/vault-gce-auth.sh -r my-vault-role
 }
 ```
 
+## Index
 
+* [vault_gce_auth](#vault_gce_auth)
+
+### vault_gce_auth
+
+Generates JSON material for login
+
+#### Example
+
+```bash
+$ gcp/vault-gce-auth.sh -r my-vault-role
+{
+  "role": "my-vault-role",
+  "http_request_method": "POST",
+  "jwt": "[[base64 encoded material]]"
+}
+```
+
+_Function has no arguments._
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v2 to v4 (all workflows)
- Upgrade `release-drafter/release-drafter` from v5 to v6
- Upgrade runner OS from `ubuntu-20.04` to `ubuntu-24.04` (all workflows)
- Upgrade `ec2-metadata-mock` from v1.8.1 to v1.13.0
- Upgrade `bats-version` from 1.2.1 to 1.11.1
- Remove manual `apt-get install shellcheck` (pre-installed on ubuntu-24.04 runners)
- Add explicit `permissions` blocks for release-drafter and shell-docs workflows
- Add `.github/dependabot.yml` for automated GitHub Actions version updates going forward

## Test plan

- [ ] Verify shellcheck-lint workflow passes on a PR
- [ ] Verify bats-unit workflow passes (ec2-metadata-mock v1.13.0 compatible)
- [ ] Verify release-drafter runs on push to main
- [ ] Verify shell-docs generates and commits doc updates